### PR TITLE
Update POM to work around bug in version plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <version>1.11</version>
   </parent>
 
+  <groupId>com.github.lstephen</groupId>
   <artifactId>ai-search</artifactId>
   <version>1.2-SNAPSHOT</version>
   <packaging>jar</packaging>


### PR DESCRIPTION
groupId is required, as mentioned here:
http://stackoverflow.com/questions/29995139/maven-versions-maven-plugin-versions-plugin-2-2
